### PR TITLE
fix a  match bug in MULTILINE_COMMENT

### DIFF
--- a/lib/as3/tokenizer.lex
+++ b/lib/as3/tokenizer.lex
@@ -530,7 +530,7 @@ XMLSTRING   ["][^"]*["]
 
 STRING   ["](\\[\x00-\xff]|[^\\"\n])*["]|['](\\[\x00-\xff]|[^\\'\n])*[']
 S 	 ([ \n\r\t\xa0]|[\xc2][\xa0])
-MULTILINE_COMMENT [/][*]+([*][^/]|[^/*]|[^*][/]|[\x00-\x1f])*[*]+[/]
+MULTILINE_COMMENT [/][*]+([*][^/]|[^/*]|[^*]?[/]|[\x00-\x1f])*[*]+[/]
 SINGLELINE_COMMENT \/\/[^\n\r]*[\n\r]
 REGEXP   [/]([^/\n]|\\[/])*[/][a-zA-Z]*
 %%


### PR DESCRIPTION
make MULTILINE_COMMENT can match /*/*/
